### PR TITLE
fix: Set User-Agent to fix blocked requests to MyTPU API

### DIFF
--- a/custom_components/mytpu/client.py
+++ b/custom_components/mytpu/client.py
@@ -33,7 +33,7 @@ class MyTPUClient:
 
     async def __aenter__(self) -> "MyTPUClient":
         """Enter async context."""
-        self._session = aiohttp.ClientSession()
+        self._session = self._create_session()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -42,10 +42,17 @@ class MyTPUClient:
             await self._session.close()
             self._session = None
 
+    def _create_session(self) -> aiohttp.ClientSession:
+        return aiohttp.ClientSession(
+            headers={
+                "User-Agent": "hass-mytpu",
+            }
+        )
+
     async def _ensure_session(self) -> aiohttp.ClientSession:
         """Ensure we have an active session."""
         if self._session is None:
-            self._session = aiohttp.ClientSession()
+            self._session = self._create_session()
         return self._session
 
     async def _request(

--- a/custom_components/mytpu/manifest.json
+++ b/custom_components/mytpu/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "aiohttp>=3.8.0"
   ],
-  "version": "1.2.1"
+  "version": "1.2.2"
 }


### PR DESCRIPTION
Fixes #14

Sets `User-Agent: hass-mytpu` on all `aiohttp.ClientSession` instances via a shared `_create_session()` method. TPU's API was blocking requests with aiohttp's default Python user-agent string, causing both the OAuth token endpoint and the JS bundle scraping to fail.