### PR TITLE
fix: Config flow KeyError and request timeout handling

### DIFF
--- a/custom_components/mytpu/__init__.py
+++ b/custom_components/mytpu/__init__.py
@@ -260,6 +260,8 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise  # propagates to _async_update_data for re-login handling
         except MyTPUError as err:
             raise UpdateFailed(f"API request failed: {err}") from err
+        except TimeoutError as err:
+            raise UpdateFailed("Request to MyTPU timed out") from err
         except Exception as err:
             _LOGGER.exception("Unexpected error communicating with TPU")
             raise UpdateFailed(

--- a/custom_components/mytpu/client.py
+++ b/custom_components/mytpu/client.py
@@ -44,9 +44,8 @@ class MyTPUClient:
 
     def _create_session(self) -> aiohttp.ClientSession:
         return aiohttp.ClientSession(
-            headers={
-                "User-Agent": "hass-mytpu",
-            }
+            headers={"User-Agent": "hass-mytpu"},
+            timeout=aiohttp.ClientTimeout(total=30),
         )
 
     async def _ensure_session(self) -> aiohttp.ClientSession:

--- a/custom_components/mytpu/config_flow.py
+++ b/custom_components/mytpu/config_flow.py
@@ -98,6 +98,7 @@ class TPUConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize the config flow."""
+        self._title: str = ""
         self._data: dict[str, Any] = {}
         self._services: list[Service] = []
 
@@ -115,8 +116,8 @@ class TPUConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(validation_result.title)
                 self._abort_if_unique_id_configured()
 
+                self._title = validation_result.title
                 self._data = {
-                    "title": validation_result.title,
                     CONF_USERNAME: user_input[CONF_USERNAME],
                     CONF_PASSWORD: user_input[CONF_PASSWORD],
                     CONF_TOKEN_DATA: validation_result.token_data,
@@ -161,7 +162,7 @@ class TPUConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
             return self.async_create_entry(
-                title=self._data.pop("title"),
+                title=self._title,
                 data=self._data,
             )
 

--- a/custom_components/mytpu/manifest.json
+++ b/custom_components/mytpu/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "aiohttp>=3.8.0"
   ],
-  "version": "1.2.2"
+  "version": "1.2.3"
 }

--- a/test/test_config_flow.py
+++ b/test/test_config_flow.py
@@ -505,6 +505,53 @@ class TestTPUConfigFlow:
             assert result["step_id"] == "meters"
             assert result["errors"] == {"base": "no_meters"}
 
+    async def test_meters_step_entry_title_not_in_data(
+        self, hass: HomeAssistant, mock_credentials, mock_token_data, mock_power_service
+    ):
+        """Test that the config entry title comes from _title, not _data.
+
+        Previously, title was stored in _data and popped at create time, which
+        raised KeyError if async_step_meters was reached via a code path that
+        didn't set it. Now _title is a separate instance variable.
+        """
+        expected_title = "TPU - Test User"
+        with patch(
+            "custom_components.mytpu.config_flow.validate_and_fetch_services"
+        ) as mock_validate:
+            mock_validate.return_value = ValidationResult(
+                title=expected_title,
+                services=[mock_power_service],
+                token_data=mock_token_data,
+            )
+
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_USER}
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], mock_credentials
+            )
+
+            power_json = json.dumps(
+                {
+                    "service_id": mock_power_service.service_id,
+                    "service_number": mock_power_service.service_number,
+                    "meter_number": mock_power_service.meter_number,
+                    "display_meter_number": mock_power_service.display_meter_number,
+                    "service_type": mock_power_service.service_type.value,
+                    "latitude": mock_power_service.latitude,
+                    "longitude": mock_power_service.longitude,
+                    "contract_number": mock_power_service.contract_number,
+                    "totalizer": mock_power_service.totalizer,
+                }
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], {CONF_POWER_SERVICE: power_json}
+            )
+
+            assert result["type"] == FlowResultType.CREATE_ENTRY
+            assert result["title"] == expected_title
+            assert "title" not in result["data"]
+
     async def test_reauth_confirm_success(
         self, hass: HomeAssistant, mock_credentials, mock_account_info, mock_token_data
     ):

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -258,6 +258,18 @@ class TestTPUDataUpdateCoordinator:
         with pytest.raises(UpdateFailed, match="API request failed"):
             await coordinator._async_update_data()
 
+    async def test_async_update_data_timeout(
+        self, hass: HomeAssistant, make_config_entry
+    ):
+        """Test data update with request timeout raises UpdateFailed."""
+        mock_client = AsyncMock()
+        mock_client.get_account_info = AsyncMock(side_effect=TimeoutError)
+        config_entry = make_config_entry(include_power=True)
+        coordinator = TPUDataUpdateCoordinator(hass, mock_client, config_entry)
+
+        with pytest.raises(UpdateFailed, match="timed out"):
+            await coordinator._async_update_data()
+
     async def test_async_update_data_server_error_no_credentials(
         self, hass: HomeAssistant, make_config_entry
     ):


### PR DESCRIPTION
Fixes #13.

- Store config entry title as a separate instance variable in the config flow instead of embedding it in `_data` and calling `pop()`, eliminating the `KeyError: 'title'` crash.
- Add a 30-second timeout to the aiohttp session and catch `TimeoutError` as `UpdateFailed` in the coordinator so a slow/hung `/rest/usage/month` request does not crash integration setup.