### PR TITLE
fix: Convert usageDate from local midnight to UTC

### DIFF
--- a/custom_components/mytpu/__init__.py
+++ b/custom_components/mytpu/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -20,6 +20,7 @@ from homeassistant.components.recorder.statistics import (
     async_add_external_statistics,
     get_last_statistics,
 )
+from homeassistant.components.recorder.util import get_instance
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
@@ -29,6 +30,7 @@ from homeassistant.const import (
 )
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .auth import AuthError, MyTPUAuth, ServerError
 from .client import MyTPUClient, MyTPUError
@@ -179,13 +181,15 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     )
 
                 power_from_date: datetime | None = None
-                if last_power_stat_time:
-                    # Request data starting from the day after the last recorded statistic
-                    # Convert the Unix timestamp (float) back to a datetime object
+                power_needs_migration = self._needs_utc_migration(last_power_stat_time)
+                if power_needs_migration:
+                    _LOGGER.info("Migrating power statistics to local-time timestamps")
+                    get_instance(self.hass).async_clear_statistics([power_statistic_id])
+                    power_from_date = datetime(datetime.now(UTC).year - 3, 1, 1)
+                elif last_power_stat_time:
                     power_from_date = datetime.fromtimestamp(
                         last_power_stat_time
                     ) + timedelta(days=1)
-                    # Set time to midnight UTC for consistency with how usageDate is parsed in models.py
                     power_from_date = power_from_date.replace(
                         hour=0, minute=0, second=0, microsecond=0
                     )
@@ -195,7 +199,10 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
                 if power_readings:
                     await self._import_statistics(
-                        self.power_service, power_readings, "energy"
+                        self.power_service,
+                        power_readings,
+                        "energy",
+                        force_reimport=power_needs_migration,
                     )
                     # Keep latest reading in data for sensor attributes
                     latest = power_readings[-1]
@@ -223,13 +230,15 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     )
 
                 water_from_date: datetime | None = None
-                if last_water_stat_time:
-                    # Request data starting from the day after the last recorded statistic
-                    # Convert the Unix timestamp (float) back to a datetime object
+                water_needs_migration = self._needs_utc_migration(last_water_stat_time)
+                if water_needs_migration:
+                    _LOGGER.info("Migrating water statistics to local-time timestamps")
+                    get_instance(self.hass).async_clear_statistics([water_statistic_id])
+                    water_from_date = datetime(datetime.now(UTC).year - 3, 1, 1)
+                elif last_water_stat_time:
                     water_from_date = datetime.fromtimestamp(
                         last_water_stat_time
                     ) + timedelta(days=1)
-                    # Set time to midnight UTC for consistency with how usageDate is parsed in models.py
                     water_from_date = water_from_date.replace(
                         hour=0, minute=0, second=0, microsecond=0
                     )
@@ -239,7 +248,10 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
                 if water_readings:
                     await self._import_statistics(
-                        self.water_service, water_readings, "water"
+                        self.water_service,
+                        water_readings,
+                        "water",
+                        force_reimport=water_needs_migration,
                     )
                     # Keep latest reading in data for sensor attributes
                     latest = water_readings[-1]
@@ -301,8 +313,33 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         else:
             _LOGGER.debug("Token data unchanged, no save needed")
 
+    @staticmethod
+    def _needs_utc_migration(last_stat_time: float | None) -> bool:
+        """Return True if the last statistic used the old UTC-midnight format.
+
+        Old code stored every reading at 00:00 UTC. New code stores at local
+        midnight converted to UTC (e.g. 08:00 UTC for PST). If the last
+        recorded statistic is at exactly 00:00 UTC and the local timezone has
+        a non-zero UTC offset, the data was written by the old code.
+        """
+        if last_stat_time is None:
+            return False
+        last_utc = datetime.fromtimestamp(last_stat_time, tz=UTC)
+        local_offset = last_utc.astimezone(dt_util.DEFAULT_TIME_ZONE).utcoffset()
+        return (
+            local_offset is not None
+            and local_offset != timedelta(0)
+            and last_utc.hour == 0
+            and last_utc.minute == 0
+        )
+
     async def _import_statistics(
-        self, service: Service, readings: list, stat_type: str
+        self,
+        service: Service,
+        readings: list,
+        stat_type: str,
+        *,
+        force_reimport: bool = False,
     ) -> None:
         """Import historical usage data as statistics."""
         if not readings:
@@ -315,19 +352,20 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         ).lower()
         statistic_id = f"{DOMAIN}:{meter_id}_{stat_type}"
 
-        # Get the last imported statistic to avoid duplicates and calculate cumulative sum
-        last_stats = await self.hass.async_add_executor_job(
-            get_last_statistics, self.hass, 1, statistic_id, True, {"sum"}
-        )
-
-        # Start cumulative sum from last known value or 0
+        # Start cumulative sum from last known value or 0.
+        # Skip the DB lookup when force_reimport is set — async_clear_statistics
+        # was already queued and the cleared data must not seed the sum.
         cumulative_sum = 0.0
         last_stat_time: float | None = None
-        if statistic_id in last_stats:
-            last_stat = last_stats[statistic_id][0]
-            cumulative_sum = last_stat.get("sum", 0.0)
-            # start is returned as a Unix timestamp (float), not a datetime
-            last_stat_time = last_stat.get("start")
+        if not force_reimport:
+            last_stats = await self.hass.async_add_executor_job(
+                get_last_statistics, self.hass, 1, statistic_id, True, {"sum"}
+            )
+            if statistic_id in last_stats:
+                last_stat = last_stats[statistic_id][0]
+                cumulative_sum = last_stat.get("sum", 0.0)
+                # start is returned as a Unix timestamp (float), not a datetime
+                last_stat_time = last_stat.get("start")
 
         # Create metadata based on type
         if stat_type == "energy":

--- a/custom_components/mytpu/__init__.py
+++ b/custom_components/mytpu/__init__.py
@@ -175,10 +175,11 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     get_last_statistics, self.hass, 1, power_statistic_id, True, {"sum"}
                 )
                 last_power_stat_time: float | None = None
+                last_power_sum = 0.0
                 if power_statistic_id in last_power_stats:
-                    last_power_stat_time = last_power_stats[power_statistic_id][0].get(
-                        "start"
-                    )
+                    last_power_stat = last_power_stats[power_statistic_id][0]
+                    last_power_stat_time = last_power_stat.get("start")
+                    last_power_sum = float(last_power_stat.get("sum") or 0.0)
 
                 power_needs_migration = self._needs_utc_migration(last_power_stat_time)
                 if power_needs_migration:
@@ -204,7 +205,10 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         self.power_service,
                         power_readings,
                         "energy",
-                        force_reimport=power_needs_migration,
+                        cumulative_sum=0.0 if power_needs_migration else last_power_sum,
+                        last_stat_time=None
+                        if power_needs_migration
+                        else last_power_stat_time,
                     )
                     # Keep latest reading in data for sensor attributes
                     latest = power_readings[-1]
@@ -226,10 +230,11 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     get_last_statistics, self.hass, 1, water_statistic_id, True, {"sum"}
                 )
                 last_water_stat_time: float | None = None
+                last_water_sum = 0.0
                 if water_statistic_id in last_water_stats:
-                    last_water_stat_time = last_water_stats[water_statistic_id][0].get(
-                        "start"
-                    )
+                    last_water_stat = last_water_stats[water_statistic_id][0]
+                    last_water_stat_time = last_water_stat.get("start")
+                    last_water_sum = float(last_water_stat.get("sum") or 0.0)
 
                 water_needs_migration = self._needs_utc_migration(last_water_stat_time)
                 if water_needs_migration:
@@ -255,7 +260,10 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         self.water_service,
                         water_readings,
                         "water",
-                        force_reimport=water_needs_migration,
+                        cumulative_sum=0.0 if water_needs_migration else last_water_sum,
+                        last_stat_time=None
+                        if water_needs_migration
+                        else last_water_stat_time,
                     )
                     # Keep latest reading in data for sensor attributes
                     latest = water_readings[-1]
@@ -343,7 +351,8 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         readings: list,
         stat_type: str,
         *,
-        force_reimport: bool = False,
+        cumulative_sum: float = 0.0,
+        last_stat_time: float | None = None,
     ) -> None:
         """Import historical usage data as statistics."""
         if not readings:
@@ -355,21 +364,6 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "-", "_"
         ).lower()
         statistic_id = f"{DOMAIN}:{meter_id}_{stat_type}"
-
-        # Start cumulative sum from last known value or 0.
-        # Skip the DB lookup when force_reimport is set — async_clear_statistics
-        # was already queued and the cleared data must not seed the sum.
-        cumulative_sum = 0.0
-        last_stat_time: float | None = None
-        if not force_reimport:
-            last_stats = await self.hass.async_add_executor_job(
-                get_last_statistics, self.hass, 1, statistic_id, True, {"sum"}
-            )
-            if statistic_id in last_stats:
-                last_stat = last_stats[statistic_id][0]
-                cumulative_sum = last_stat.get("sum", 0.0)
-                # start is returned as a Unix timestamp (float), not a datetime
-                last_stat_time = last_stat.get("start")
 
         # Create metadata based on type
         if stat_type == "energy":

--- a/custom_components/mytpu/__init__.py
+++ b/custom_components/mytpu/__init__.py
@@ -180,15 +180,17 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         "start"
                     )
 
-                power_from_date: datetime | None = None
                 power_needs_migration = self._needs_utc_migration(last_power_stat_time)
                 if power_needs_migration:
                     _LOGGER.info("Migrating power statistics to local-time timestamps")
                     get_instance(self.hass).async_clear_statistics([power_statistic_id])
-                    power_from_date = datetime(datetime.now(UTC).year - 3, 1, 1)
-                elif last_power_stat_time:
+                if power_needs_migration or not last_power_stat_time:
+                    power_from_date = datetime(
+                        datetime.now(UTC).year - 3, 1, 1, tzinfo=UTC
+                    )
+                else:
                     power_from_date = datetime.fromtimestamp(
-                        last_power_stat_time
+                        last_power_stat_time, tz=UTC
                     ) + timedelta(days=1)
                     power_from_date = power_from_date.replace(
                         hour=0, minute=0, second=0, microsecond=0
@@ -229,15 +231,17 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         "start"
                     )
 
-                water_from_date: datetime | None = None
                 water_needs_migration = self._needs_utc_migration(last_water_stat_time)
                 if water_needs_migration:
                     _LOGGER.info("Migrating water statistics to local-time timestamps")
                     get_instance(self.hass).async_clear_statistics([water_statistic_id])
-                    water_from_date = datetime(datetime.now(UTC).year - 3, 1, 1)
-                elif last_water_stat_time:
+                if water_needs_migration or not last_water_stat_time:
+                    water_from_date = datetime(
+                        datetime.now(UTC).year - 3, 1, 1, tzinfo=UTC
+                    )
+                else:
                     water_from_date = datetime.fromtimestamp(
-                        last_water_stat_time
+                        last_water_stat_time, tz=UTC
                     ) + timedelta(days=1)
                     water_from_date = water_from_date.replace(
                         hour=0, minute=0, second=0, microsecond=0

--- a/custom_components/mytpu/__init__.py
+++ b/custom_components/mytpu/__init__.py
@@ -186,9 +186,7 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     _LOGGER.info("Migrating power statistics to local-time timestamps")
                     get_instance(self.hass).async_clear_statistics([power_statistic_id])
                 if power_needs_migration or not last_power_stat_time:
-                    power_from_date = datetime(
-                        datetime.now(UTC).year - 3, 1, 1, tzinfo=UTC
-                    )
+                    power_from_date = datetime.now(UTC) - timedelta(days=90)
                 else:
                     power_from_date = datetime.fromtimestamp(
                         last_power_stat_time, tz=UTC
@@ -241,9 +239,7 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     _LOGGER.info("Migrating water statistics to local-time timestamps")
                     get_instance(self.hass).async_clear_statistics([water_statistic_id])
                 if water_needs_migration or not last_water_stat_time:
-                    water_from_date = datetime(
-                        datetime.now(UTC).year - 3, 1, 1, tzinfo=UTC
-                    )
+                    water_from_date = datetime.now(UTC) - timedelta(days=90)
                 else:
                     water_from_date = datetime.fromtimestamp(
                         last_water_stat_time, tz=UTC

--- a/custom_components/mytpu/__init__.py
+++ b/custom_components/mytpu/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.components.recorder.models import (
 from homeassistant.components.recorder.statistics import (
     async_add_external_statistics,
     get_last_statistics,
+    statistics_during_period,
 )
 from homeassistant.components.recorder.util import get_instance
 from homeassistant.const import (
@@ -181,19 +182,22 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     last_power_stat_time = last_power_stat.get("start")
                     last_power_sum = float(last_power_stat.get("sum") or 0.0)
 
-                power_needs_migration = self._needs_utc_migration(last_power_stat_time)
-                if power_needs_migration:
+                if self._needs_utc_migration(last_power_stat_time):
                     _LOGGER.info("Migrating power statistics to local-time timestamps")
-                    get_instance(self.hass).async_clear_statistics([power_statistic_id])
-                if power_needs_migration or not last_power_stat_time:
-                    power_from_date = datetime.now(UTC) - timedelta(days=90)
-                else:
-                    power_from_date = datetime.fromtimestamp(
-                        last_power_stat_time, tz=UTC
-                    ) + timedelta(days=1)
-                    power_from_date = power_from_date.replace(
-                        hour=0, minute=0, second=0, microsecond=0
+                    (
+                        last_power_sum,
+                        last_power_stat_time,
+                    ) = await self._migrate_statistics(
+                        power_statistic_id, self.power_service, "energy"
                     )
+
+                if last_power_stat_time:
+                    power_from_date = (
+                        datetime.fromtimestamp(last_power_stat_time, tz=UTC)
+                        + timedelta(days=1)
+                    ).replace(hour=0, minute=0, second=0, microsecond=0)
+                else:
+                    power_from_date = datetime.now(UTC) - timedelta(days=90)
 
                 power_readings = await self.client.get_usage(
                     self.power_service, from_date=power_from_date
@@ -203,10 +207,8 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         self.power_service,
                         power_readings,
                         "energy",
-                        cumulative_sum=0.0 if power_needs_migration else last_power_sum,
-                        last_stat_time=None
-                        if power_needs_migration
-                        else last_power_stat_time,
+                        cumulative_sum=last_power_sum,
+                        last_stat_time=last_power_stat_time,
                     )
                     # Keep latest reading in data for sensor attributes
                     latest = power_readings[-1]
@@ -234,19 +236,22 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     last_water_stat_time = last_water_stat.get("start")
                     last_water_sum = float(last_water_stat.get("sum") or 0.0)
 
-                water_needs_migration = self._needs_utc_migration(last_water_stat_time)
-                if water_needs_migration:
+                if self._needs_utc_migration(last_water_stat_time):
                     _LOGGER.info("Migrating water statistics to local-time timestamps")
-                    get_instance(self.hass).async_clear_statistics([water_statistic_id])
-                if water_needs_migration or not last_water_stat_time:
-                    water_from_date = datetime.now(UTC) - timedelta(days=90)
-                else:
-                    water_from_date = datetime.fromtimestamp(
-                        last_water_stat_time, tz=UTC
-                    ) + timedelta(days=1)
-                    water_from_date = water_from_date.replace(
-                        hour=0, minute=0, second=0, microsecond=0
+                    (
+                        last_water_sum,
+                        last_water_stat_time,
+                    ) = await self._migrate_statistics(
+                        water_statistic_id, self.water_service, "water"
                     )
+
+                if last_water_stat_time:
+                    water_from_date = (
+                        datetime.fromtimestamp(last_water_stat_time, tz=UTC)
+                        + timedelta(days=1)
+                    ).replace(hour=0, minute=0, second=0, microsecond=0)
+                else:
+                    water_from_date = datetime.now(UTC) - timedelta(days=90)
 
                 water_readings = await self.client.get_usage(
                     self.water_service, from_date=water_from_date
@@ -256,10 +261,8 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         self.water_service,
                         water_readings,
                         "water",
-                        cumulative_sum=0.0 if water_needs_migration else last_water_sum,
-                        last_stat_time=None
-                        if water_needs_migration
-                        else last_water_stat_time,
+                        cumulative_sum=last_water_sum,
+                        last_stat_time=last_water_stat_time,
                     )
                     # Keep latest reading in data for sensor attributes
                     latest = water_readings[-1]
@@ -340,6 +343,75 @@ class TPUDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             and last_utc.hour == 0
             and last_utc.minute == 0
         )
+
+    async def _migrate_statistics(
+        self,
+        statistic_id: str,
+        service: Service,
+        stat_type: str,
+    ) -> tuple[float, float | None]:
+        """Re-timestamp existing statistics from UTC midnight to local-midnight UTC.
+
+        Returns (last_cumulative_sum, last_stat_time) so the caller can compute
+        an incremental from_date without re-querying TPU for historical data.
+        """
+        all_stats = await self.hass.async_add_executor_job(
+            statistics_during_period,
+            self.hass,
+            datetime(1970, 1, 1, tzinfo=UTC),
+            None,
+            {statistic_id},
+            "hour",
+            None,
+            {"state", "sum"},
+        )
+        existing = all_stats.get(statistic_id, [])
+        if not existing:
+            return 0.0, None
+
+        corrected = [
+            StatisticData(
+                start=dt_util.as_utc(
+                    datetime(
+                        (old_utc := datetime.fromtimestamp(stat["start"], tz=UTC)).year,
+                        old_utc.month,
+                        old_utc.day,
+                        tzinfo=dt_util.DEFAULT_TIME_ZONE,
+                    )
+                ),
+                state=float(stat.get("state") or 0.0),
+                sum=float(stat.get("sum") or 0.0),
+            )
+            for stat in existing
+        ]
+
+        get_instance(self.hass).async_clear_statistics([statistic_id])
+
+        if stat_type == "energy":
+            metadata = StatisticMetaData(
+                mean_type=StatisticMeanType.NONE,
+                has_sum=True,
+                name=f"TPU Energy {service.display_meter_number}",
+                source=DOMAIN,
+                statistic_id=statistic_id,
+                unit_class="energy",
+                unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+            )
+        else:
+            metadata = StatisticMetaData(
+                mean_type=StatisticMeanType.NONE,
+                has_sum=True,
+                name=f"TPU Water {service.display_meter_number}",
+                source=DOMAIN,
+                statistic_id=statistic_id,
+                unit_class="volume",
+                unit_of_measurement=UnitOfVolume.CENTUM_CUBIC_FEET,
+            )
+
+        async_add_external_statistics(self.hass, metadata, corrected)
+
+        last = corrected[-1]
+        return float(last["sum"] or 0.0), last["start"].timestamp()
 
     async def _import_statistics(
         self,

--- a/custom_components/mytpu/manifest.json
+++ b/custom_components/mytpu/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "aiohttp>=3.8.0"
   ],
-  "version": "1.2.3"
+  "version": "1.2.4"
 }

--- a/custom_components/mytpu/models.py
+++ b/custom_components/mytpu/models.py
@@ -34,12 +34,13 @@ class UsageReading:
             with contextlib.suppress(ValueError, TypeError):
                 peak_time = datetime.strptime(data["demandPeakTime"], "%Y-%m-%d %H:%M")
 
-        # Parse date as UTC midnight using dt_util.parse_datetime
-        # Append time and Z to indicate UTC
-        utc_date_str = f"{data['usageDate']}T00:00:00Z"
-        utc_date = dt_util.parse_datetime(utc_date_str)
-        if utc_date is None:
-            raise ValueError(f"Failed to parse date: {data['usageDate']}")
+        # Parse usageDate as midnight in HA's local timezone, then convert to UTC.
+        # The API returns local (Pacific) calendar dates; storing as UTC midnight
+        # would cause the Energy Dashboard to display readings shifted by UTC offset.
+        local_midnight = datetime.strptime(data["usageDate"], "%Y-%m-%d").replace(
+            tzinfo=dt_util.DEFAULT_TIME_ZONE
+        )
+        utc_date = dt_util.as_utc(local_midnight)
 
         return cls(
             date=utc_date,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,6 +33,15 @@ def pacific_timezone():
     dt_util.set_default_time_zone(previous)
 
 
+@pytest.fixture()
+def utc_timezone():
+    """Temporarily override the HA timezone to UTC for a single test."""
+    previous = dt_util.DEFAULT_TIME_ZONE
+    dt_util.set_default_time_zone(ZoneInfo("UTC"))
+    yield
+    dt_util.set_default_time_zone(previous)
+
+
 # Custom component fixtures
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,9 +3,11 @@
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock
+from zoneinfo import ZoneInfo
 
 import pytest
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.mytpu.auth import MyTPUAuth
@@ -20,6 +22,15 @@ from custom_components.mytpu.models import Service, ServiceType
 
 # This fixture is required for all tests
 pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def pacific_timezone():
+    """Set HA timezone to America/Los_Angeles for the test, then restore."""
+    previous = dt_util.DEFAULT_TIME_ZONE
+    dt_util.set_default_time_zone(ZoneInfo("America/Los_Angeles"))
+    yield
+    dt_util.set_default_time_zone(previous)
 
 
 # Custom component fixtures

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -258,10 +258,10 @@ class TestMyTPUClient:
                     )
 
                     assert len(readings) == 2
-                    assert readings[0].date == datetime(2026, 1, 1, tzinfo=UTC)
+                    assert readings[0].date == datetime(2026, 1, 1, 8, 0, tzinfo=UTC)
                     assert readings[0].consumption == 25.5
                     assert readings[0].unit == "kWh"
-                    assert readings[1].date == datetime(2026, 1, 2, tzinfo=UTC)
+                    assert readings[1].date == datetime(2026, 1, 2, 8, 0, tzinfo=UTC)
                     assert readings[1].consumption == 28.3
 
     async def test_get_usage_default_dates(
@@ -467,7 +467,7 @@ class TestMyTPUClient:
 
                     # Only the D entry should be returned; M entries are filtered
                     assert len(readings) == 1
-                    assert readings[0].date == datetime(2026, 1, 1, tzinfo=UTC)
+                    assert readings[0].date == datetime(2026, 1, 1, 8, 0, tzinfo=UTC)
                     assert readings[0].consumption == 25.5
 
     async def test_async_login(self):

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -16,6 +16,7 @@ from custom_components.mytpu import (
     _service_from_config,
     async_setup_entry,
     async_unload_entry,
+    update_listener,
 )
 from custom_components.mytpu.auth import AuthError, ServerError
 from custom_components.mytpu.client import MyTPUError
@@ -64,6 +65,13 @@ def test_service_from_config_minimal():
     assert service.service_id == "123"
     assert service.service_type == ServiceType.WATER
     assert service.totalizer is False
+
+
+async def test_update_listener(hass: HomeAssistant, mock_config_entry):
+    """update_listener reloads the config entry."""
+    with patch.object(hass.config_entries, "async_reload") as mock_reload:
+        await update_listener(hass, mock_config_entry)
+        mock_reload.assert_called_once_with(mock_config_entry.entry_id)
 
 
 async def test_async_setup_entry(hass: HomeAssistant, mock_config_entry):
@@ -586,6 +594,132 @@ class TestTPUDataUpdateCoordinator:
             assert metadata["statistic_id"] == f"{DOMAIN}:w_mock_water_meter_water"
             assert "TPU Water" in metadata["name"]
             assert metadata["unit_class"] == "volume"
+
+    def test_needs_utc_migration_none(self):
+        """No existing statistics never triggers migration."""
+        assert TPUDataUpdateCoordinator._needs_utc_migration(None) is False
+
+    def test_needs_utc_migration_old_format(self):
+        """UTC-midnight stat with non-UTC timezone triggers migration."""
+        midnight_utc = datetime(2025, 1, 15, 0, 0, tzinfo=UTC).timestamp()
+        assert TPUDataUpdateCoordinator._needs_utc_migration(midnight_utc) is True
+
+    def test_needs_utc_migration_new_format(self):
+        """Local-midnight-in-UTC stat does not trigger migration."""
+        # 08:00 UTC = midnight PST
+        local_midnight_utc = datetime(2025, 1, 15, 8, 0, tzinfo=UTC).timestamp()
+        assert (
+            TPUDataUpdateCoordinator._needs_utc_migration(local_midnight_utc) is False
+        )
+
+    def test_needs_utc_migration_utc_timezone(self, utc_timezone):
+        """UTC-midnight stat with UTC timezone does not trigger migration."""
+        midnight_utc = datetime(2025, 1, 15, 0, 0, tzinfo=UTC).timestamp()
+        assert TPUDataUpdateCoordinator._needs_utc_migration(midnight_utc) is False
+
+    async def test_async_update_data_migration(
+        self, hass: HomeAssistant, mock_config_entry
+    ):
+        """Old UTC-midnight statistics are cleared and re-fetched from 3 years back."""
+        mock_client = AsyncMock()
+        mock_client.get_account_info = AsyncMock()
+        mock_client.get_token_data = MagicMock(return_value=None)
+        mock_client.get_usage = AsyncMock(return_value=[])
+
+        coordinator = TPUDataUpdateCoordinator(hass, mock_client, mock_config_entry)
+
+        power_statistic_id = f"{DOMAIN}:p_mock_power_meter_energy"
+        water_statistic_id = f"{DOMAIN}:w_mock_water_meter_water"
+        old_stat_time = datetime(2025, 1, 14, 0, 0, tzinfo=UTC).timestamp()
+        mock_recorder = MagicMock()
+
+        with (
+            patch(
+                "custom_components.mytpu.get_last_statistics",
+                return_value={
+                    power_statistic_id: [{"sum": 100.0, "start": old_stat_time}],
+                    water_statistic_id: [{"sum": 10.0, "start": old_stat_time}],
+                },
+            ),
+            patch("custom_components.mytpu.get_instance", return_value=mock_recorder),
+        ):
+            await coordinator._async_update_data()
+
+        assert mock_recorder.async_clear_statistics.call_count == 2
+        from_date = mock_client.get_usage.call_args_list[0].kwargs["from_date"]
+        assert from_date.year == datetime.now(UTC).year - 3
+
+    async def test_import_statistics_force_reimport(
+        self, hass: HomeAssistant, mock_power_service, make_config_entry
+    ):
+        """Test force_reimport skips the DB lookup and starts the sum from zero."""
+        mock_client = AsyncMock()
+        config_entry = make_config_entry()
+        coordinator = TPUDataUpdateCoordinator(hass, mock_client, config_entry)
+
+        readings = [
+            UsageReading(
+                date=datetime(2026, 1, 1, 8, 0, tzinfo=UTC),
+                consumption=25.5,
+                unit="kWh",
+            )
+        ]
+
+        with (
+            patch("custom_components.mytpu.get_last_statistics") as mock_get_stats,
+            patch(
+                "custom_components.mytpu.async_add_external_statistics"
+            ) as mock_add_stats,
+        ):
+            await coordinator._import_statistics(
+                mock_power_service, readings, "energy", force_reimport=True
+            )
+
+            mock_get_stats.assert_not_called()
+            args = mock_add_stats.call_args.args
+            statistics = args[2]
+            # baseline (sum=0) + one reading
+            assert len(statistics) == 2
+            assert statistics[0]["sum"] == 0.0
+            assert statistics[1]["sum"] == 25.5
+
+    async def test_async_update_data_existing_stats_no_migration(
+        self, hass: HomeAssistant, mock_config_entry
+    ):
+        """Existing stats at non-midnight UTC (new format) compute from_date without migrating."""
+        mock_client = AsyncMock()
+        mock_client.get_account_info = AsyncMock()
+        mock_client.get_token_data = MagicMock(return_value=None)
+        mock_client.get_usage = AsyncMock(return_value=[])
+
+        coordinator = TPUDataUpdateCoordinator(hass, mock_client, mock_config_entry)
+
+        power_statistic_id = f"{DOMAIN}:p_mock_power_meter_energy"
+        water_statistic_id = f"{DOMAIN}:w_mock_water_meter_water"
+        # New format: midnight PST = 08:00 UTC (not midnight UTC, so no migration)
+        new_stat_time = datetime(2025, 1, 15, 8, 0, tzinfo=UTC).timestamp()
+
+        with patch(
+            "custom_components.mytpu.get_last_statistics",
+            return_value={
+                power_statistic_id: [{"sum": 100.0, "start": new_stat_time}],
+                water_statistic_id: [{"sum": 10.0, "start": new_stat_time}],
+            },
+        ):
+            await coordinator._async_update_data()
+
+        # Both services requested data starting from the day after Jan 15
+        assert mock_client.get_usage.call_count == 2
+        power_from_date = mock_client.get_usage.call_args_list[0].kwargs["from_date"]
+        assert power_from_date.day == 16
+
+    async def test_import_statistics_empty_readings(
+        self, hass: HomeAssistant, mock_power_service, make_config_entry
+    ):
+        """Empty reading list returns immediately without touching the recorder."""
+        mock_client = AsyncMock()
+        coordinator = TPUDataUpdateCoordinator(hass, mock_client, make_config_entry())
+        await coordinator._import_statistics(mock_power_service, [], "energy")
 
     async def test_import_statistics_meter_id_sanitization(
         self, hass: HomeAssistant, make_config_entry

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -713,6 +713,28 @@ class TestTPUDataUpdateCoordinator:
         power_from_date = mock_client.get_usage.call_args_list[0].kwargs["from_date"]
         assert power_from_date.day == 16
 
+    async def test_async_update_data_no_stats_fetches_three_years(
+        self, hass: HomeAssistant, mock_config_entry
+    ):
+        """No existing statistics (fresh install or post-migration clear) fetches 3 years back."""
+        mock_client = AsyncMock()
+        mock_client.get_account_info = AsyncMock()
+        mock_client.get_token_data = MagicMock(return_value=None)
+        mock_client.get_usage = AsyncMock(return_value=[])
+
+        coordinator = TPUDataUpdateCoordinator(hass, mock_client, mock_config_entry)
+
+        with patch(
+            "custom_components.mytpu.get_last_statistics",
+            return_value={},
+        ):
+            await coordinator._async_update_data()
+
+        assert mock_client.get_usage.call_count == 2
+        from_date = mock_client.get_usage.call_args_list[0].kwargs["from_date"]
+        assert from_date.year == datetime.now(UTC).year - 3
+        assert from_date.tzinfo is not None
+
     async def test_import_statistics_empty_readings(
         self, hass: HomeAssistant, mock_power_service, make_config_entry
     ):

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -622,7 +622,7 @@ class TestTPUDataUpdateCoordinator:
 
         assert mock_recorder.async_clear_statistics.call_count == 2
         from_date = mock_client.get_usage.call_args_list[0].kwargs["from_date"]
-        assert from_date.year == datetime.now(UTC).year - 3
+        assert (datetime.now(UTC) - from_date).days <= 90
 
     async def test_import_statistics_zero_sum_baseline(
         self, hass: HomeAssistant, mock_power_service, make_config_entry
@@ -682,10 +682,10 @@ class TestTPUDataUpdateCoordinator:
         power_from_date = mock_client.get_usage.call_args_list[0].kwargs["from_date"]
         assert power_from_date.day == 16
 
-    async def test_async_update_data_no_stats_fetches_three_years(
+    async def test_async_update_data_no_stats_fetches_90_days(
         self, hass: HomeAssistant, mock_config_entry
     ):
-        """No existing statistics (fresh install or post-migration clear) fetches 3 years back."""
+        """No existing statistics (fresh install or post-migration clear) fetches 90 days back."""
         mock_client = AsyncMock()
         mock_client.get_account_info = AsyncMock()
         mock_client.get_token_data = MagicMock(return_value=None)
@@ -701,7 +701,7 @@ class TestTPUDataUpdateCoordinator:
 
         assert mock_client.get_usage.call_count == 2
         from_date = mock_client.get_usage.call_args_list[0].kwargs["from_date"]
-        assert from_date.year == datetime.now(UTC).year - 3
+        assert (datetime.now(UTC) - from_date).days <= 90
         assert from_date.tzinfo is not None
 
     async def test_import_statistics_empty_readings(

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -433,12 +433,9 @@ class TestTPUDataUpdateCoordinator:
             ),
         ]
 
-        with (
-            patch("custom_components.mytpu.get_last_statistics", return_value={}),
-            patch(
-                "custom_components.mytpu.async_add_external_statistics"
-            ) as mock_add_stats,
-        ):
+        with patch(
+            "custom_components.mytpu.async_add_external_statistics"
+        ) as mock_add_stats:
             await coordinator._import_statistics(mock_power_service, readings, "energy")
 
             mock_add_stats.assert_called_once()
@@ -479,28 +476,18 @@ class TestTPUDataUpdateCoordinator:
             ),
         ]
 
-        # Mock existing statistics
-        # start is returned as a Unix timestamp (float)
         last_stat_time = dt_util.as_utc(datetime(2026, 1, 2)).timestamp()
-        mock_last_stats = {
-            f"{DOMAIN}:p_mock_power_meter_energy": [
-                {
-                    "sum": 100.0,
-                    "start": last_stat_time,
-                }
-            ]
-        }
 
-        with (
-            patch(
-                "custom_components.mytpu.get_last_statistics",
-                return_value=mock_last_stats,
-            ),
-            patch(
-                "custom_components.mytpu.async_add_external_statistics"
-            ) as mock_add_stats,
-        ):
-            await coordinator._import_statistics(mock_power_service, readings, "energy")
+        with patch(
+            "custom_components.mytpu.async_add_external_statistics"
+        ) as mock_add_stats:
+            await coordinator._import_statistics(
+                mock_power_service,
+                readings,
+                "energy",
+                cumulative_sum=100.0,
+                last_stat_time=last_stat_time,
+            )
 
             mock_add_stats.assert_called_once()
             # Extract arguments: async_add_external_statistics(hass, metadata, statistics)
@@ -534,27 +521,18 @@ class TestTPUDataUpdateCoordinator:
         ]
 
         # Mock that we already have data up to Jan 2
-        # start is returned as a Unix timestamp (float)
         last_stat_time = dt_util.as_utc(datetime(2026, 1, 2)).timestamp()
-        mock_last_stats = {
-            f"{DOMAIN}:p_mock_power_meter_energy": [
-                {
-                    "sum": 100.0,
-                    "start": last_stat_time,
-                }
-            ]
-        }
 
-        with (
-            patch(
-                "custom_components.mytpu.get_last_statistics",
-                return_value=mock_last_stats,
-            ),
-            patch(
-                "custom_components.mytpu.async_add_external_statistics"
-            ) as mock_add_stats,
-        ):
-            await coordinator._import_statistics(mock_power_service, readings, "energy")
+        with patch(
+            "custom_components.mytpu.async_add_external_statistics"
+        ) as mock_add_stats:
+            await coordinator._import_statistics(
+                mock_power_service,
+                readings,
+                "energy",
+                cumulative_sum=100.0,
+                last_stat_time=last_stat_time,
+            )
 
             # Should not add any statistics (all duplicates)
             mock_add_stats.assert_not_called()
@@ -575,12 +553,9 @@ class TestTPUDataUpdateCoordinator:
             ),
         ]
 
-        with (
-            patch("custom_components.mytpu.get_last_statistics", return_value={}),
-            patch(
-                "custom_components.mytpu.async_add_external_statistics"
-            ) as mock_add_stats,
-        ):
+        with patch(
+            "custom_components.mytpu.async_add_external_statistics"
+        ) as mock_add_stats:
             await coordinator._import_statistics(mock_water_service, readings, "water")
 
             mock_add_stats.assert_called_once()
@@ -649,10 +624,10 @@ class TestTPUDataUpdateCoordinator:
         from_date = mock_client.get_usage.call_args_list[0].kwargs["from_date"]
         assert from_date.year == datetime.now(UTC).year - 3
 
-    async def test_import_statistics_force_reimport(
+    async def test_import_statistics_zero_sum_baseline(
         self, hass: HomeAssistant, mock_power_service, make_config_entry
     ):
-        """Test force_reimport skips the DB lookup and starts the sum from zero."""
+        """cumulative_sum=0 (default) adds a baseline entry before the first reading."""
         mock_client = AsyncMock()
         config_entry = make_config_entry()
         coordinator = TPUDataUpdateCoordinator(hass, mock_client, config_entry)
@@ -665,17 +640,11 @@ class TestTPUDataUpdateCoordinator:
             )
         ]
 
-        with (
-            patch("custom_components.mytpu.get_last_statistics") as mock_get_stats,
-            patch(
-                "custom_components.mytpu.async_add_external_statistics"
-            ) as mock_add_stats,
-        ):
-            await coordinator._import_statistics(
-                mock_power_service, readings, "energy", force_reimport=True
-            )
+        with patch(
+            "custom_components.mytpu.async_add_external_statistics"
+        ) as mock_add_stats:
+            await coordinator._import_statistics(mock_power_service, readings, "energy")
 
-            mock_get_stats.assert_not_called()
             args = mock_add_stats.call_args.args
             statistics = args[2]
             # baseline (sum=0) + one reading
@@ -767,12 +736,9 @@ class TestTPUDataUpdateCoordinator:
             ),
         ]
 
-        with (
-            patch("custom_components.mytpu.get_last_statistics", return_value={}),
-            patch(
-                "custom_components.mytpu.async_add_external_statistics"
-            ) as mock_add_stats,
-        ):
+        with patch(
+            "custom_components.mytpu.async_add_external_statistics"
+        ) as mock_add_stats:
             await coordinator._import_statistics(service, readings, "energy")
 
             # Extract arguments: async_add_external_statistics(hass, metadata, statistics)

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -570,6 +570,18 @@ class TestTPUDataUpdateCoordinator:
             assert "TPU Water" in metadata["name"]
             assert metadata["unit_class"] == "volume"
 
+    async def test_migrate_statistics_empty(
+        self, hass: HomeAssistant, mock_power_service, make_config_entry
+    ):
+        """_migrate_statistics returns zeros when statistics_during_period finds nothing."""
+        coordinator = TPUDataUpdateCoordinator(hass, AsyncMock(), make_config_entry())
+        with patch("custom_components.mytpu.statistics_during_period", return_value={}):
+            result_sum, result_time = await coordinator._migrate_statistics(
+                f"{DOMAIN}:p_mock_power_meter_energy", mock_power_service, "energy"
+            )
+        assert result_sum == 0.0
+        assert result_time is None
+
     def test_needs_utc_migration_none(self):
         """No existing statistics never triggers migration."""
         assert TPUDataUpdateCoordinator._needs_utc_migration(None) is False
@@ -595,7 +607,7 @@ class TestTPUDataUpdateCoordinator:
     async def test_async_update_data_migration(
         self, hass: HomeAssistant, mock_config_entry
     ):
-        """Old UTC-midnight statistics are cleared and re-fetched from 3 years back."""
+        """Old UTC-midnight statistics are re-timestamped in place; TPU is only queried for new data."""
         mock_client = AsyncMock()
         mock_client.get_account_info = AsyncMock()
         mock_client.get_token_data = MagicMock(return_value=None)
@@ -605,8 +617,15 @@ class TestTPUDataUpdateCoordinator:
 
         power_statistic_id = f"{DOMAIN}:p_mock_power_meter_energy"
         water_statistic_id = f"{DOMAIN}:w_mock_water_meter_water"
+        # Old-format: stored at UTC midnight (PST would be 08:00 UTC)
         old_stat_time = datetime(2025, 1, 14, 0, 0, tzinfo=UTC).timestamp()
         mock_recorder = MagicMock()
+
+        existing_stats = {
+            "sum": 100.0,
+            "start": old_stat_time,
+            "state": 25.5,
+        }
 
         with (
             patch(
@@ -616,13 +635,30 @@ class TestTPUDataUpdateCoordinator:
                     water_statistic_id: [{"sum": 10.0, "start": old_stat_time}],
                 },
             ),
+            patch(
+                "custom_components.mytpu.statistics_during_period",
+                return_value={
+                    power_statistic_id: [existing_stats],
+                    water_statistic_id: [existing_stats],
+                },
+            ),
             patch("custom_components.mytpu.get_instance", return_value=mock_recorder),
+            patch(
+                "custom_components.mytpu.async_add_external_statistics"
+            ) as mock_add_stats,
         ):
             await coordinator._async_update_data()
 
+        # Stats cleared and re-inserted with corrected timestamps
         assert mock_recorder.async_clear_statistics.call_count == 2
+        assert mock_add_stats.call_count == 2
+        corrected_start = mock_add_stats.call_args_list[0].args[2][0]["start"]
+        # 2025-01-14 UTC midnight → 2025-01-14 08:00 UTC (PST = UTC-8)
+        assert corrected_start == datetime(2025, 1, 14, 8, 0, tzinfo=UTC)
+
+        # TPU is queried only for new data: the day after the last corrected stat
         from_date = mock_client.get_usage.call_args_list[0].kwargs["from_date"]
-        assert (datetime.now(UTC) - from_date).days <= 90
+        assert from_date == datetime(2025, 1, 15, 0, 0, tzinfo=UTC)
 
     async def test_import_statistics_zero_sum_baseline(
         self, hass: HomeAssistant, mock_power_service, make_config_entry

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -37,7 +37,7 @@ class TestUsageReading:
         }
         reading = UsageReading.from_api_response(data)
 
-        assert reading.date == datetime(2026, 1, 15, tzinfo=UTC)
+        assert reading.date == datetime(2026, 1, 15, 8, 0, tzinfo=UTC)
         assert reading.consumption == 25.5
         assert reading.unit == "kWh"
         assert reading.high_temp == 45.0
@@ -51,7 +51,7 @@ class TestUsageReading:
         }
         reading = UsageReading.from_api_response(data)
 
-        assert reading.date == datetime(2026, 1, 15, tzinfo=UTC)
+        assert reading.date == datetime(2026, 1, 15, 8, 0, tzinfo=UTC)
         assert reading.consumption == 0.0
         assert reading.unit == ""
         assert reading.high_temp is None
@@ -103,6 +103,18 @@ class TestUsageReading:
 
         assert reading.consumption == 0.0
         assert reading.unit == "CCF"
+
+    def test_date_pst_converts_to_utc(self):
+        """Test that a date in PST (UTC-8) is stored as midnight+8h UTC."""
+        data = {"usageDate": "2025-02-16"}  # February is PST (UTC-8)
+        reading = UsageReading.from_api_response(data)
+        assert reading.date == datetime(2025, 2, 16, 8, 0, tzinfo=UTC)
+
+    def test_date_pdt_converts_to_utc(self):
+        """Test that a date in PDT (UTC-7) is stored as midnight+7h UTC."""
+        data = {"usageDate": "2025-07-15"}  # July is PDT (UTC-7)
+        reading = UsageReading.from_api_response(data)
+        assert reading.date == datetime(2025, 7, 15, 7, 0, tzinfo=UTC)
 
 
 class TestService:


### PR DESCRIPTION
## Summary

- \`usageDate\` from the API is a local (Pacific) calendar date; the old code stored it as UTC midnight, causing the Energy Dashboard to display readings shifted by the UTC offset (e.g. \"2025-03-15 4:00 PM\" instead of \"2025-03-16\")
- Fix interprets the date as midnight in HA's configured local timezone and converts to UTC, so \"2025-02-16\" becomes \`2025-02-16 08:00 UTC\` (PST) and \"2025-07-15\" becomes \`2025-07-15 07:00 UTC\` (PDT)
- Existing statistics with old UTC-midnight timestamps are detected automatically and migrated **in place** — each timestamp is shifted to the correct local-midnight UTC value (accounting for DST) without re-querying the TPU API; all historical data is preserved
- After migration, TPU is only queried for new data since the last corrected stat — same as a normal incremental refresh
- Fresh installs with no existing statistics fetch the last 90 days of history
- Adds a \`pacific_timezone\` autouse fixture in \`conftest.py\` so all tests reflect real-world timezone behavior; adds explicit PST and PDT test cases

Fixes #12